### PR TITLE
Use the User model passed from the gate check

### DIFF
--- a/src/Feature.php
+++ b/src/Feature.php
@@ -26,16 +26,17 @@ class Feature
      *
      * @param string $featureKey
      * @param mixed $variant (optional)
+     * @param \Illuminate\Contracts\Auth\Access\Authorizable $user (optional)
      * @return bool
      */
-    public function isEnabled($featureKey, $variant = null)
+    public function isEnabled($featureKey, $variant = null, $user = null)
     {
         if (! $variant) {
             $variant = $this->getConfig($featureKey);
         }
 
         if ($variant != self::ON and $variant != self::OFF) {
-            return $this->isUserEnabled($variant);
+            return $this->isUserEnabled($variant, $user);
         }
 
         return $variant == self::ON;
@@ -62,11 +63,12 @@ class Feature
 
     /**
      * @param $feature_variant
+     * @param \Illuminate\Contracts\Auth\Access\Authorizable $user (optional)
      * @return bool
      */
-    protected function isUserEnabled($feature_variant)
+    protected function isUserEnabled($feature_variant, $user = null)
     {
-        if ($user_email = $this->getUserEmail()) {
+        if ($user_email = $this->getUserEmail($user)) {
             if (empty($feature_variant['users'])) {
                 return false;
             }
@@ -83,11 +85,15 @@ class Feature
 
 
     /**
-     * @param string|int $userId
+     * @param \Illuminate\Contracts\Auth\Access\Authorizable $user (optional)
      * @return string
      */
-    public function getUserEmail()
+    public function getUserEmail($user)
     {
+        if ($user && $user->email) {
+            return $user->email;
+        }
+
         if (Auth::guest()) {
             return false;
         }

--- a/src/FeatureFlagsProvider.php
+++ b/src/FeatureFlagsProvider.php
@@ -2,11 +2,12 @@
 
 namespace FriendsOfCat\LaravelFeatureFlags;
 
-use FriendsOfCat\LaravelFeatureFlags\Console\Command\SyncFlags;
-use Illuminate\Foundation\Support\Providers\AuthServiceProvider as ServiceProvider;
-use Illuminate\Contracts\Auth\Access\Gate as GateContract;
+use Exception;
 use Illuminate\Support\Facades\Log;
 use Facades\FriendsOfCat\LaravelFeatureFlags\Feature;
+use Illuminate\Contracts\Auth\Access\Gate as GateContract;
+use FriendsOfCat\LaravelFeatureFlags\Console\Command\SyncFlags;
+use Illuminate\Foundation\Support\Providers\AuthServiceProvider as ServiceProvider;
 
 /**
  * Class FeatureFlagsProvider
@@ -115,9 +116,9 @@ class FeatureFlagsProvider extends ServiceProvider
     {
         $gate->define('feature-flag', function ($user, $flag_id) {
             try {
-                return Feature::isEnabled($flag_id);
-            } catch (\Exception $e) {
-                if (config("laravel-feature-flag.logging")) {
+                return Feature::isEnabled($flag_id, null, $user);
+            } catch (Exception $e) {
+                if (config('laravel-feature-flag.logging')) {
                     Log::info(
                         sprintf(
                             "FeatureFlagsProvider: error with feature flag %s. '%s'",
@@ -126,6 +127,7 @@ class FeatureFlagsProvider extends ServiceProvider
                         )
                     );
                 }
+
                 // Defaults to false in case of error.
                 return false;
             }

--- a/tests/FeatureTest.php
+++ b/tests/FeatureTest.php
@@ -56,6 +56,40 @@ class FeatureTest extends TestCase
      * @test
      * @covers ::isEnabled
      */
+    public function testIsEnabledPassingKeyAndUser()
+    {
+        $user = factory(FeatureFlagUser::class)->create();
+
+        factory(FeatureFlag::class)->create([
+            'key' => 'feature_1',
+            'variants' => 'on'
+        ]);
+
+        factory(FeatureFlag::class)->create([
+            'key' => 'feature_2',
+            'variants' => 'off'
+        ]);
+
+        factory(FeatureFlag::class)->create([
+            'key' => 'feature_3',
+            'variants' => ['users' => [$user->email]],
+        ]);
+
+        factory(FeatureFlag::class)->create([
+            'key' => 'feature_3',
+            'variants' => ['users' => []],
+        ]);
+
+        $this->assertTrue((new Feature)->isEnabled('feature_1', null, $user));
+        $this->assertFalse((new Feature)->isEnabled('feature_2', null, $user));
+        $this->assertTrue((new Feature)->isEnabled('feature_3', null, $user));
+        $this->assertFalse((new Feature)->isEnabled('feature_4', null, $user));
+    }
+
+    /**
+     * @test
+     * @covers ::isEnabled
+     */
     public function testIsEnabledPassingVariant()
     {
         $user = factory(FeatureFlagUser::class)->create();


### PR DESCRIPTION
This allow us to check if the user has the feature check enabled in queued jobs, where the user is not really "logged in". e.g.

```php
$document->user->can('feature-flag', 'fragments');
```

This currently doesn't work because the email of the user is retrieved using the `Auth::user()`.