### PR TITLE
Added functionality to support user roles in feature flag configuration

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,17 +26,18 @@
     "toggles"
   ],
   "require": {
-    "php": "^7.1.3" 
+    "php": "^7.1.3"
   },
   "require-dev": {
+    "doctrine/dbal": "2.9.3",
     "illuminate/support": "^5.6",
     "mockery/mockery": "0.9.*",
+    "orchestra/database": "^3.6.0",
     "orchestra/testbench": "^3.6",
+    "php-coveralls/php-coveralls": "^2.1",
     "phpunit/phpunit": "^7.0",
     "ramsey/uuid": "^3.0",
-    "orchestra/database": "^3.6.0",
-    "squizlabs/php_codesniffer": "^2.3",
-    "php-coveralls/php-coveralls": "^2.1"
+    "squizlabs/php_codesniffer": "^2.3"
   },
   "autoload": {
     "psr-4": {

--- a/database/factories/ModelFactory.php
+++ b/database/factories/ModelFactory.php
@@ -14,6 +14,7 @@ $factory->define(\FriendsOfCat\LaravelFeatureFlags\FeatureFlagUser::class, funct
     return [
         'name' => $faker->word,
         'email' => $faker->email,
-        'password' => bcrypt(str_random(25))
+        'password' => bcrypt(str_random(25)),
+        'roles' => "['admin']"
     ];
 });

--- a/readme.md
+++ b/readme.md
@@ -138,18 +138,15 @@ i.e.
 { "roles": ["admin", "dev"]}
 ~~~
 
-If you don't have a roles property in your User model, you just need to implement the **FeatureFlagsUserRoles** Interface and the following method
+If you don't have a roles property in your User model, you just need to implement the **FeatureFlagsEnabler** Interface and use **FeatureFlagUserRoleTrait**
 
 ~~~
-use FriendsOfCat\LaravelFeatureFlags\FeatureFlagsUserRoles;
+use FriendsOfCat\LaravelFeatureFlags\FeatureFlagsEnabler;
+use FriendsOfCat\LaravelFeatureFlags\FeatureFlagUserRoleTrait;
 
 class User extends Authenticatable implements FeatureFlagsUserRoles
 {
-    public function getRolesForFeatureFlags(): ?array
-    {
-
-        // return user roles array
-    }
+    use AuthenticableTrait, FeatureFlagUserRoleTrait;
 }
 ~~~
 

--- a/readme.md
+++ b/readme.md
@@ -129,6 +129,29 @@ if(\FriendsOfCat\LaravelFeatureFlags\Feature::exists('see-twitter-field'))
 }
 ~~~
 
+### Enable for User Roles
+You can enable a feature flag for specific user roles, by using the **roles** variant in the configuration form
+
+i.e.
+
+~~~
+{ "roles": ["admin", "dev"]}
+~~~
+
+If you don't have a roles property in your User model, you just need to implement the **FeatureFlagsUserRoles** Interface and the following method
+
+~~~
+use FriendsOfCat\LaravelFeatureFlags\FeatureFlagsUserRoles;
+
+class User extends Authenticatable implements FeatureFlagsUserRoles
+{
+    public function getRolesForFeatureFlags(): ?array
+    {
+
+        // return user roles array
+    }
+}
+~~~
 
 ## Usage Non Auth
 

--- a/src/FeatureFlagHelper.php
+++ b/src/FeatureFlagHelper.php
@@ -46,6 +46,10 @@ trait FeatureFlagHelper
             $features[$value['key']]['users'] = $value['variants']['users'];
         }
 
+        if (isset($value['variants']['roles'])) {
+            $features[$value['key']]['roles'] = $value['variants']['roles'];
+        }
+
         return $features;
     }
 

--- a/src/FeatureFlagUserRoleTrait.php
+++ b/src/FeatureFlagUserRoleTrait.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace FriendsOfCat\LaravelFeatureFlags;
+
+trait FeatureFlagUserRoleTrait
+{
+    public function getFieldValueForFeatureFlags(string $fieldName): ?array
+    {
+        return (array) json_decode($this->$fieldName, true);
+    }
+}

--- a/src/FeatureFlagsEnabler.php
+++ b/src/FeatureFlagsEnabler.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace FriendsOfCat\LaravelFeatureFlags;
+
+interface FeatureFlagsEnabler
+{
+    public function getFieldValueForFeatureFlags(string $fieldName): ?array;
+}

--- a/tests/FeatureFlagTest.php
+++ b/tests/FeatureFlagTest.php
@@ -111,4 +111,49 @@ class FeatureFlagTest extends TestCase
         $this->assertFalse($this->app->get(Gate::class)->allows('feature-flag', 'testing'));
     }
 
+    public function testOnForUserRole()
+    {
+        $this->user = factory(FeatureFlagUser::class)->create(['email' => 'foo2@gmail.com']);
+        $this->user->setRawAttributes(['roles' => ['admin', 'editor']]);
+
+        $this->be($this->user);
+
+        factory(FeatureFlag::class)->create(
+            [
+                'key' => 'testing',
+                'variants' => [
+                    'roles' => [
+                        'admin'
+                    ]
+                ]
+            ]
+        );
+
+        $this->registerFeatureFlags();
+
+        $this->assertTrue($this->app->get(Gate::class)->allows('feature-flag', 'testing'));
+    }
+
+    public function testOffForUserRole()
+    {
+        $this->user = factory(FeatureFlagUser::class)->create(['email' => 'foo2@gmail.com']);
+        $this->user->setRawAttributes(['roles' => ['editor']]);
+
+        $this->be($this->user);
+
+        factory(FeatureFlag::class)->create(
+            [
+                'key' => 'testing',
+                'variants' => [
+                    'roles' => [
+                        'admin', 'manager'
+                    ]
+                ]
+            ]
+        );
+
+        $this->registerFeatureFlags();
+
+        $this->assertFalse($this->app->get(Gate::class)->allows('feature-flag', 'testing'));
+    }
 }

--- a/tests/FeatureFlagsEnablerTest.php
+++ b/tests/FeatureFlagsEnablerTest.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace Tests;
+
+use Illuminate\Contracts\Auth\Access\Gate;
+use Illuminate\Foundation\Testing\WithFaker;
+use FriendsOfCat\LaravelFeatureFlags\FeatureFlag;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use FriendsOfCat\LaravelFeatureFlags\FeatureFlagHelper;
+use Tests\fixtures\UserWithFeatureFlagsEnablerInterface;
+
+class FeatureFlagsEnablerTest extends TestCase
+{
+    use RefreshDatabase, WithFaker, FeatureFlagHelper;
+
+    /**
+     * @dataProvider validData
+     */
+    public function testItWorksWhenInterfaceImplented($userRoles)
+    {
+        $user = new UserWithFeatureFlagsEnablerInterface([
+            'name' => $this->faker->word,
+            'email' => $this->faker->email,
+            'password' => bcrypt(str_random(25)),
+            'roles' => json_encode($userRoles)
+        ]);
+        $user->save();
+        
+        $this->be($user);
+
+        factory(FeatureFlag::class)->create(
+            [
+                'key' => 'testing',
+                'variants' => [
+                    'roles' => [
+                        'developer', 'admin'
+                    ]
+                ]
+            ]
+        );
+
+        $this->registerFeatureFlags();
+
+        $this->assertTrue($this->app->get(Gate::class)->allows('feature-flag', 'testing'));
+    }
+
+    public function validData()
+    {
+        return [
+                [
+                    'admin'
+                ],
+                [
+                    ['admin', 'developer']
+                ],
+                [
+                    'developer'
+                ]
+        ];
+    }
+}

--- a/tests/fixtures/UserWithFeatureFlagsEnablerInterface.php
+++ b/tests/fixtures/UserWithFeatureFlagsEnablerInterface.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Tests\fixtures;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Contracts\Auth\Authenticatable;
+use FriendsOfCat\LaravelFeatureFlags\FeatureFlagsEnabler;
+use FriendsOfCat\LaravelFeatureFlags\FeatureFlagUserRoleTrait;
+use Illuminate\Auth\Authenticatable as AuthenticableTrait;
+
+class UserWithFeatureFlagsEnablerInterface extends Model implements Authenticatable, FeatureFlagsEnabler
+{
+    use AuthenticableTrait, FeatureFlagUserRoleTrait;
+
+    protected $table = 'users';
+    protected $fillable = ['name', 'email', 'password', 'roles'];
+
+    public function __construct(array $attributes = [ ])
+    {
+        parent::__construct($attributes);
+    }
+}

--- a/tests/migrations/2020_09_11_1141689_add_roles_in_users_table.php
+++ b/tests/migrations/2020_09_11_1141689_add_roles_in_users_table.php
@@ -1,0 +1,24 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class AddRolesInUsersTable extends Migration
+{
+    public function up()
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->string('roles')->nullable();
+        });
+    }
+
+    public function down()
+    {
+        if (Schema::hasColumn('users', 'roles')) {
+            Schema::table('users', function (Blueprint $table) {
+                    $table->dropColumn('roles');
+            });
+        }
+    }
+}

--- a/views/form.blade.php
+++ b/views/form.blade.php
@@ -21,6 +21,12 @@
             <pre>{ "users": [ "foo@gmail.com" ] }</pre>
             or
             <br>
+            <pre>{ "roles": [ "developer" ] }</pre>
+            or
+            <br>
+            <pre>{ "roles": [ "developer" ], "users": [ "foo@bar.com" ] }</pre>
+            or
+            <br>
             <pre>"off"</pre>
         </div>
     </div>


### PR DESCRIPTION
User roles now supported in feature flag configuration.
`{"roles" : ["admin"]}`

You can also use a mixture of user roles and user emails
`{"roles" : ["admin", "developer"], "users": ["foo@bar.com"]}`