### PR TITLE
Use once to reduce number of queries

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,12 @@
-dist: trusty
+dist: bionic
 language: php
 
 php:
   - 7.1
   - 7.2
+  - 7.3
+  - 7.4
+  - 8.0
 
 # This triggers builds to run on the new TravisCI infrastructure.
 # See: http://docs.travis-ci.com/user/workers/container-based-infrastructure/
@@ -17,8 +20,9 @@ cache:
     - vendor
 
 before_script:
+  - composer self-update --stable
   - travis_retry composer update ${COMPOSER_FLAGS} --no-interaction --prefer-dist
-  - composer install --prefer-dist  --no-interaction
+  - composer install --prefer-dist --no-interaction --no-progress
 
 script:
   - vendor/bin/phpcs --standard=psr2 src/

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,8 @@
     "toggles"
   ],
   "require": {
-    "php": "^7.1.3"
+    "php": "^7.1.3",
+    "spatie/once": "^2.0"
   },
   "require-dev": {
     "doctrine/dbal": "2.9.3",

--- a/src/Feature.php
+++ b/src/Feature.php
@@ -2,10 +2,10 @@
 
 namespace FriendsOfCat\LaravelFeatureFlags;
 
+use FriendsOfCat\LaravelFeatureFlags\FeatureFlagsEnabler;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Cache;
-use FriendsOfCat\LaravelFeatureFlags\FeatureFlagsEnabler;
 
 class Feature
 {
@@ -24,12 +24,12 @@ class Feature
     }
 
     /**
-    * Check if a feature flag exists.
-    *
-    * @param string $featureKey
-    * @param mixed $variant (optional)
-    * @return bool
-    */
+     * Check if a feature flag exists.
+     *
+     * @param string $featureKey
+     * @param mixed $variant (optional)
+     * @return bool
+     */
     public function exists($featureKey)
     {
         return isset($this->instance[$featureKey]);
@@ -62,17 +62,19 @@ class Feature
      */
     public function getConfig($featureKey)
     {
-        if (isset($this->instance[$featureKey])) {
+        if (array_key_exists($featureKey, $this->instance)) {
             return $this->instance[$featureKey];
         }
 
-        $featureFlag = FeatureFlag::where('key', $featureKey)->first();
+        $featureFlag = once(function () use ($featureKey) {
+            return FeatureFlag::where('key', $featureKey)->first();
+        });
 
-        if (isset($featureFlag)) {
-            return  $featureFlag->variants;
+        if ($featureFlag === null) {
+            return self::OFF;
         }
 
-        return self::OFF;
+        return $featureFlag->variants;
     }
 
     /**


### PR DESCRIPTION
I noticed that each time a feature flag is checked, it issues a new database query.

This PR introduces [Spatie’s once][1] library so that a database query is only issued once for each feature flag within a single request.

[1]: https://github.com/spatie/once